### PR TITLE
Uses Dataframe.map instead of applymap if it is available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 changed
 ~~~~~~
 - (`#151 <https://github.com/GranthamImperial/silicone/pull/151>`_) Improved error handling and structured logging in ratio-based crunchers and utilities.
+- (`#153 <https://github.com/GranthamImperial/silicone/pull/153>`_) Use :func:`pandas.DataFrame.map` in preference to :func:`pandas.DataFrame.applymap` as the later was deprecated in Pandas v2.1.0.
 
 [v1.3.0] - 14 Oct 2022
 ----------------------

--- a/src/silicone/database_crunchers/quantile_rolling_windows.py
+++ b/src/silicone/database_crunchers/quantile_rolling_windows.py
@@ -9,7 +9,7 @@ import scipy.interpolate
 from pyam import IamDataFrame
 
 from ..stats import rolling_window_find_quantiles
-from ..utils import _get_unit_of_variable
+from ..utils import _get_unit_of_variable, _remove_missing_values
 from .base import _DatabaseCruncher
 
 logger = logging.getLogger(__name__)
@@ -177,10 +177,7 @@ class QuantileRollingWindows(_DatabaseCruncher):
         wide_db = self._db.filter(
             variable=[variable_follower] + variable_leaders
         ).pivot_table(index=idx, columns=columns, aggfunc="sum")
-
-        # make sure we don't have empty strings floating around (pyam bug?)
-        wide_db = wide_db.applymap(lambda x: np.nan if isinstance(x, str) else x)
-        wide_db = wide_db.dropna(axis=0)
+        wide_db = _remove_missing_values(wide_db)
 
         derived_relationships = {}
         for db_time, dbtdf in wide_db.groupby(db_time_col):


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [ ] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added


## Description

`pandas.DataFrame.applymap` has been deprecated to be replaced with `[pandas.DataFrame.map](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.map.html#pandas.DataFrame.map)` in pandas >=2.1.0.
This uses `.map` if it is available to avoid getting a `FutureWarning`.

```
2025-08-15 05:46:21,274 WARNING py.warnings MainProcess/8372248768: /Users/jared/code/cr/core-api/.venv/lib/python3.10/site-packages/silicone/database_crunchers/quantile_rolling_windows.py:182: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  wide_db = wide_db.applymap(lambda x: np.nan if isinstance(x, str) else x)
```
